### PR TITLE
[100][Feature] The weather details should depend on the selected time in the hour-schedule

### DIFF
--- a/src/common/types/IWeather.ts
+++ b/src/common/types/IWeather.ts
@@ -7,7 +7,7 @@ export interface IWeather {
 }
 
 export interface IForecastday {
-  hour: Array<iHour>;
+  hour: Array<IHour>;
   day: IDay;
   date: string;
 }
@@ -78,7 +78,7 @@ interface Current {
   gust_kph: number;
 }
 
-interface iHour extends Current {
+export interface IHour extends Current {
   time: string;
 }
 

--- a/src/store/slices/weatherSlice.ts
+++ b/src/store/slices/weatherSlice.ts
@@ -1,23 +1,29 @@
 import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
-import { IWeather } from '../../common/types/IWeather';
+import { IHour, IWeather } from '../../common/types/IWeather';
 
 export const weatherSlice = createSlice({
   name: 'weather',
   initialState: {
+    // weatherData is unused
     weatherData: {} as IWeather,
     dayOfTheWeek: 0,
+    weatherHour: null as IHour | null,
   },
   reducers: {
-    getWeather: (state, action: PayloadAction<IWeather>) => {
+    putWeather: (state, action: PayloadAction<IWeather>) => {
       state.weatherData = action.payload;
     },
     putDayOfWeek: (state, action: PayloadAction<number>) => {
       state.dayOfTheWeek = action.payload;
     },
+    putWeatherHourInfo: (state, action: PayloadAction<IHour>) => {
+      state.weatherHour = action.payload;
+    },
   },
 });
 
-export const { getWeather, putDayOfWeek } = weatherSlice.actions;
+export const { putWeather, putDayOfWeek, putWeatherHourInfo } =
+  weatherSlice.actions;
 
 export default weatherSlice.reducer;

--- a/src/ui/circular-loader/circular-with-lebel/circular-with-lebel.style.ts
+++ b/src/ui/circular-loader/circular-with-lebel/circular-with-lebel.style.ts
@@ -1,5 +1,3 @@
-import { circularProgressClasses } from '@mui/material';
-
 export const styles = {
   circular_wrapper: {
     margin: '10px',

--- a/src/ui/forecast/forecast.tsx
+++ b/src/ui/forecast/forecast.tsx
@@ -1,15 +1,15 @@
 import { styles } from './forecast.styles';
 import InputCity from './input-city/input-city';
-import WeatherDetails from './weather-details/weather-details';
 import CircularLoader from '../circular-loader/circural-loader';
 import { IWeather } from '../../common/types/IWeather';
 import { FC } from 'react';
 import { Box } from '@mui/material';
 import HourScheduleWidgetContainer from '../forecast/hour-schedule-widget/hour-schedule-widget.container';
 import WeekScheduleContainer from './week-schedule/week-schedule.container';
+import WeatherDetailsContainer from './weather-details/weather-details.container';
 
 interface Props {
-  data: IWeather;
+  data: IWeather | undefined;
 }
 
 const Forecast: FC<Props> = ({ data }) => {
@@ -26,7 +26,7 @@ const Forecast: FC<Props> = ({ data }) => {
             <CircularLoader />
           </Box>
         )}
-        {data ? <WeatherDetails weather={data} /> : <CircularLoader />}
+        <WeatherDetailsContainer />
       </Box>
       {data ? (
         <HourScheduleWidgetContainer days={data.forecast.forecastday} />

--- a/src/ui/forecast/hour-schedule-widget/hour-schedule-widget.container.tsx
+++ b/src/ui/forecast/hour-schedule-widget/hour-schedule-widget.container.tsx
@@ -1,19 +1,34 @@
 import { FC } from 'react';
-import { IForecastday } from '../../common/types/IWeather';
-import ScheduleWidget from './hour-schedule-widget';
-import { useSelector } from 'react-redux';
-import { IRootState } from '../../common/types/store';
+import HourScheduleWidget from './hour-schedule-widget';
+import { useDispatch, useSelector } from 'react-redux';
+import { IForecastday, IHour } from '../../../common/types/IWeather';
+import { IRootState } from '../../../common/types/store';
+import { putWeatherHourInfo } from '../../../store/slices/weatherSlice';
 
 interface Props {
   days: Array<IForecastday>;
 }
 
 const HourScheduleWidgetContainer: FC<Props> = ({ days }) => {
+  const dispatch = useDispatch();
   const dayIndex = useSelector(
     (state: IRootState) => state.weather.dayOfTheWeek
   );
 
-  return <>{<ScheduleWidget schedule={days[dayIndex].hour} />}</>;
+  const handleClick = (hoursData: IHour ) => {
+    dispatch(putWeatherHourInfo(hoursData));
+  };
+
+  return (
+    <>
+      {
+        <HourScheduleWidget
+          schedule={days[dayIndex].hour}
+          callback={handleClick}
+        />
+      }
+    </>
+  );
 };
 
 export default HourScheduleWidgetContainer;

--- a/src/ui/forecast/hour-schedule-widget/hour-schedule-widget.tsx
+++ b/src/ui/forecast/hour-schedule-widget/hour-schedule-widget.tsx
@@ -1,5 +1,5 @@
 import { Box, Typography } from '@mui/material';
-import { FC, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 import HourScheduleItem from './hour-schedule-item/hour-schedule-item';
 import { getHour } from './hour-schedule-widget.helpers';
 import { styles } from './hour-schedule-widget.styles';
@@ -16,8 +16,12 @@ const HourScheduleWidget: FC<Props> = ({ schedule, callback }) => {
 
   const handleListItemClick = (index: number) => {
     setSelectedIndex(index);
-    callback && callback(schedule[selectedIndex]);
   };
+
+  useEffect(() => {
+    callback && callback(schedule[selectedIndex]);
+  }, [selectedIndex]);
+
   return (
     <Box component='div' sx={styles.box_container}>
       <Box sx={styles.title_wrapper}>

--- a/src/ui/forecast/hour-schedule-widget/hour-schedule-widget.tsx
+++ b/src/ui/forecast/hour-schedule-widget/hour-schedule-widget.tsx
@@ -20,7 +20,7 @@ const HourScheduleWidget: FC<Props> = ({ schedule, callback }) => {
 
   useEffect(() => {
     callback && callback(schedule[selectedIndex]);
-  }, [selectedIndex]);
+  }, [selectedIndex, schedule]);
 
   return (
     <Box component='div' sx={styles.box_container}>

--- a/src/ui/forecast/hour-schedule-widget/hour-schedule-widget.tsx
+++ b/src/ui/forecast/hour-schedule-widget/hour-schedule-widget.tsx
@@ -3,12 +3,12 @@ import { FC, useState } from 'react';
 import HourScheduleItem from './hour-schedule-item/hour-schedule-item';
 import { getHour } from './hour-schedule-widget.helpers';
 import { styles } from './hour-schedule-widget.styles';
-import { IForecastday } from '../../../common/types/IWeather';
+import { IForecastday, IHour } from '../../../common/types/IWeather';
 import { curLabel } from '../../../common/lang/lang';
 
 interface Props {
   schedule: IForecastday['hour'];
-  callback?: (index: number) => void;
+  callback?: (hour: IHour) => void;
 }
 
 const HourScheduleWidget: FC<Props> = ({ schedule, callback }) => {
@@ -16,7 +16,7 @@ const HourScheduleWidget: FC<Props> = ({ schedule, callback }) => {
 
   const handleListItemClick = (index: number) => {
     setSelectedIndex(index);
-    callback && callback(index);
+    callback && callback(schedule[selectedIndex]);
   };
   return (
     <Box component='div' sx={styles.box_container}>

--- a/src/ui/forecast/weather-details/weather-details.container.tsx
+++ b/src/ui/forecast/weather-details/weather-details.container.tsx
@@ -1,0 +1,23 @@
+import WeatherDetails from './weather-details';
+import { useSelector } from 'react-redux';
+import { IRootState } from '../../../common/types/store';
+import CircularLoader from '../../circular-loader/circural-loader';
+
+const WeatherDetailsContainer = () => {
+  const hourInfo = useSelector(
+    (state: IRootState) => state.weather.weatherHour
+  );
+  return (
+    <>
+      {hourInfo ? (
+        <WeatherDetails hour={hourInfo} />
+      ) : (
+        <div>
+          <CircularLoader />
+        </div>
+      )}
+    </>
+  );
+};
+
+export default WeatherDetailsContainer;

--- a/src/ui/forecast/weather-details/weather-details.tsx
+++ b/src/ui/forecast/weather-details/weather-details.tsx
@@ -1,44 +1,44 @@
 import React from 'react';
 import WeatherItem from './weather-item/weather-item';
-import { IWeather } from '../../../common/types/IWeather';
+import { IHour } from '../../../common/types/IWeather';
 import { WeatherItems } from './weather-details.consts';
 import { Container, WeatherContainer, Wrapper } from './weather-details.styles';
 import { curLabel } from '../../../common/lang/lang';
 import { getMetersPerSecond } from './weather-details.helpers';
 
 type Props = {
-  weather: IWeather | undefined;
+  hour: IHour;
 };
 
-const WeatherDetails: React.FC<Props> = ({ weather }) => {
+const WeatherDetails: React.FC<Props> = ({ hour }) => {
   return (
     <Wrapper>
       <Container>
         <h4>{curLabel.WeatherDetails.TITLE}</h4>
-        {weather && (
+        {hour && (
           <WeatherContainer>
-            <h3>{weather.current.condition.text.toUpperCase()}</h3>
+            <h3>{hour.condition.text.toUpperCase()}</h3>
             <WeatherItem
               name={WeatherItems.Humidity.name}
-              value={weather.current.humidity}
+              value={hour.humidity}
               unitOfMeasure={WeatherItems.Humidity.unitOfMeasure}
               icon={WeatherItems.Humidity.icon}
             ></WeatherItem>
             <WeatherItem
               name={WeatherItems.Cloudy.name}
-              value={weather.current.cloud}
+              value={hour.cloud}
               unitOfMeasure={WeatherItems.Cloudy.unitOfMeasure}
               icon={WeatherItems.Cloudy.icon}
             ></WeatherItem>
             <WeatherItem
               name={WeatherItems.Wind.name}
-              value={getMetersPerSecond(weather.current.wind_kph)}
+              value={getMetersPerSecond(hour.wind_kph)}
               unitOfMeasure={WeatherItems.Wind.unitOfMeasure}
               icon={WeatherItems.Wind.icon}
             ></WeatherItem>
             <WeatherItem
               name={WeatherItems.FeelsLike.name}
-              value={Math.round(weather.current.feelslike_c)}
+              value={Math.round(hour.feelslike_c)}
               unitOfMeasure={WeatherItems.FeelsLike.unitOfMeasure}
               icon={WeatherItems.FeelsLike.icon}
             ></WeatherItem>


### PR DESCRIPTION
1. Feature] The weather details should depend on the selected time in the hour-schedule
2. Refactoring
3. [Bug] After forecast loading indicators must be visible
4. [Bug] After select another day indicators must be show actual hour info
![image](https://github.com/user-attachments/assets/274090af-a1d2-407d-ad41-c0fa296452ec)
